### PR TITLE
refactor duplicate code for creating a new output device

### DIFF
--- a/audioled/serverconfiguration.py
+++ b/audioled/serverconfiguration.py
@@ -49,7 +49,7 @@ class ServerConfiguration:
         ]:
             print("Renewing device")
             self._reusableDevice = None
-            self.getActiveProjectOrDefault().setDevice(self._createOutputDevice())
+            self.getActiveProjectOrDefault().setDevice(self.createOutputDevice())
 
     def getConfiguration(self, key):
         if key in self._config:
@@ -75,7 +75,7 @@ class ServerConfiguration:
 
     def initDefaultProject(self):
         # Initialize default project
-        proj = project.Project("Default project", "This is the default project.", self._createOutputDevice())
+        proj = project.Project("Default project", "This is the default project.", self.createOutputDevice())
         # Initialize filtergraph
         # fg = configs.createSpectrumGraph(num_pixels, device)
         # fg = configs.createMovingLightGraph(num_pixels, device)
@@ -99,7 +99,7 @@ class ServerConfiguration:
     def getProject(self, uid):
         if uid in self._projects:
             proj = self._projects[uid]
-            proj.setDevice(self._createOutputDevice())
+            proj.setDevice(self.createOutputDevice())
             proj.id = uid
             return proj
         return None
@@ -130,7 +130,7 @@ class ServerConfiguration:
         return data
 
     def createEmptyProject(self, title, description):
-        proj = project.Project(title, description, self._createOutputDevice())
+        proj = project.Project(title, description, self.createOutputDevice())
         projectUid = uuid.uuid4().hex
         self._projects[projectUid] = proj
         self._projectMetadatas[projectUid] = self._metadataForProject(proj, projectUid)
@@ -142,7 +142,7 @@ class ServerConfiguration:
         if not isinstance(proj, project.Project):
             raise RuntimeError("Imported object is not a project")
         projectUid = uuid.uuid4().hex
-        proj.setDevice(self._createOutputDevice())
+        proj.setDevice(self.createOutputDevice())
         self._projects[projectUid] = proj
         self._projectMetadatas[projectUid] = self._metadataForProject(proj, projectUid)
         return self.getProjectMetadata(projectUid)
@@ -159,20 +159,22 @@ class ServerConfiguration:
     def _load(self):
         pass
 
-    def _createOutputDevice(self):
+    def createOutputDevice(self):
         if self._reusableDevice is not None:
             return self._reusableDevice
         device = None
         print("Injecting device: {}".format(self.getConfiguration(CONFIG_DEVICE)))
         if self.getConfiguration(CONFIG_DEVICE) == devices.RaspberryPi.__name__:
             device = devices.RaspberryPi(
-                self.getConfiguration(CONFIG_NUM_PIXELS), 
-                self.getConfiguration(CONFIG_NUM_ROWS))
+                    self.getConfiguration(CONFIG_NUM_PIXELS)
+                    , self.getConfiguration(CONFIG_NUM_ROWS)
+                )
         elif self.getConfiguration(CONFIG_DEVICE) == devices.FadeCandy.__name__:
             device = devices.FadeCandy(
-                self.getConfiguration(CONFIG_NUM_PIXELS), 
-                self.getConfiguration(CONFIG_NUM_ROWS),
-                self.getConfiguration(CONFIG_DEVICE_CANDY_SERVER))
+                    self.getConfiguration(CONFIG_NUM_PIXELS)
+                    , self.getConfiguration(CONFIG_NUM_ROWS)
+                    , self.getConfiguration(CONFIG_DEVICE_CANDY_SERVER)
+                )
         else:
             print("Unknown device: {}".format(self.getConfiguration(CONFIG_DEVICE)))
         if self.getConfiguration(CONFIG_DEVICE_PANEL_MAPPING) is not None and self.getConfiguration(
@@ -442,7 +444,7 @@ class PersistentConfiguration(ServerConfiguration):
             content = fc.read()
             proj = jsonpickle.decode(content)
             proj._contentRoot = os.path.dirname(filepath)
-            proj.setDevice(self._createOutputDevice())
+            proj.setDevice(self.createOutputDevice())
             return proj
 
     def _writeProject(self, proj, projFile):

--- a/audioled/serverconfiguration.py
+++ b/audioled/serverconfiguration.py
@@ -49,7 +49,7 @@ class ServerConfiguration:
         ]:
             print("Renewing device")
             self._reusableDevice = None
-            self.getActiveProjectOrDefault().setDevice(self.createOutputDevice())
+            self.getActiveProjectOrDefault().setDevice(self._createOrReuseOutputDevice())
 
     def getConfiguration(self, key):
         if key in self._config:
@@ -75,7 +75,7 @@ class ServerConfiguration:
 
     def initDefaultProject(self):
         # Initialize default project
-        proj = project.Project("Default project", "This is the default project.", self.createOutputDevice())
+        proj = project.Project("Default project", "This is the default project.", self._createOrReuseOutputDevice())
         # Initialize filtergraph
         # fg = configs.createSpectrumGraph(num_pixels, device)
         # fg = configs.createMovingLightGraph(num_pixels, device)
@@ -99,7 +99,7 @@ class ServerConfiguration:
     def getProject(self, uid):
         if uid in self._projects:
             proj = self._projects[uid]
-            proj.setDevice(self.createOutputDevice())
+            proj.setDevice(self._createOrReuseOutputDevice())
             proj.id = uid
             return proj
         return None
@@ -112,7 +112,7 @@ class ServerConfiguration:
 
     def activateProject(self, uid):
         #if self._activeProject is not None:
-            #self._activeProject.setDevice(None)
+        #self._activeProject.setDevice(None)
         proj = self.getProject(uid)
         if proj is not None:
             self._config[CONFIG_ACTIVE_PROJECT] = uid
@@ -130,7 +130,7 @@ class ServerConfiguration:
         return data
 
     def createEmptyProject(self, title, description):
-        proj = project.Project(title, description, self.createOutputDevice())
+        proj = project.Project(title, description, self._createOrReuseOutputDevice())
         projectUid = uuid.uuid4().hex
         self._projects[projectUid] = proj
         self._projectMetadatas[projectUid] = self._metadataForProject(proj, projectUid)
@@ -142,7 +142,7 @@ class ServerConfiguration:
         if not isinstance(proj, project.Project):
             raise RuntimeError("Imported object is not a project")
         projectUid = uuid.uuid4().hex
-        proj.setDevice(self.createOutputDevice())
+        proj.setDevice(self._createOrReuseOutputDevice())
         self._projects[projectUid] = proj
         self._projectMetadatas[projectUid] = self._metadataForProject(proj, projectUid)
         return self.getProjectMetadata(projectUid)
@@ -159,22 +159,22 @@ class ServerConfiguration:
     def _load(self):
         pass
 
-    def createOutputDevice(self):
+    def _createOrReuseOutputDevice(self):
         if self._reusableDevice is not None:
             return self._reusableDevice
-        device = None
-        print("Injecting device: {}".format(self.getConfiguration(CONFIG_DEVICE)))
+        device = self.createOutputDevice()
+        self._reusableDevice = device
+        return device
+
+    def createOutputDevice(self):
+        print("Creating device: {}".format(self.getConfiguration(CONFIG_DEVICE)))
         if self.getConfiguration(CONFIG_DEVICE) == devices.RaspberryPi.__name__:
             device = devices.RaspberryPi(
-                    self.getConfiguration(CONFIG_NUM_PIXELS)
-                    , self.getConfiguration(CONFIG_NUM_ROWS)
-                )
+                self.getConfiguration(CONFIG_NUM_PIXELS), self.getConfiguration(CONFIG_NUM_ROWS))
         elif self.getConfiguration(CONFIG_DEVICE) == devices.FadeCandy.__name__:
             device = devices.FadeCandy(
-                    self.getConfiguration(CONFIG_NUM_PIXELS)
-                    , self.getConfiguration(CONFIG_NUM_ROWS)
-                    , self.getConfiguration(CONFIG_DEVICE_CANDY_SERVER)
-                )
+                self.getConfiguration(CONFIG_NUM_PIXELS), self.getConfiguration(CONFIG_NUM_ROWS),
+                self.getConfiguration(CONFIG_DEVICE_CANDY_SERVER))
         else:
             print("Unknown device: {}".format(self.getConfiguration(CONFIG_DEVICE)))
         if self.getConfiguration(CONFIG_DEVICE_PANEL_MAPPING) is not None and self.getConfiguration(
@@ -189,7 +189,6 @@ class ServerConfiguration:
                     print("Active pixel mapping: {}".format(mappingFile))
             else:
                 raise FileNotFoundError("Mapping file {} does not exist.".format(mappingFile))
-        self._reusableDevice = device
         return device
 
     def _metadataForProject(self, project, projectUid):
@@ -201,7 +200,7 @@ class ServerConfiguration:
 
     def store(self):
         pass
-    
+
     def getProjectAsset(self, projectUid, location):
         if os.path.exists(location):
             filename = os.path.basename(location)
@@ -212,7 +211,7 @@ class ServerConfiguration:
                 return [io.BytesIO(b.read()), filename, mimetype]
         print("Cannot find project asset {}".format(location))
         return None
-    
+
     def addProjectAsset(self, projectUid, file):
         raise RuntimeError("Cannot add project asset for in-memory server configuration")
 
@@ -306,7 +305,7 @@ class PersistentConfiguration(ServerConfiguration):
                     os.makedirs(path)
                 self._writeProject(proj, projFile)
                 self._lastProjectHashs[key] = projHash
-    
+
     def postStore(self):
         for key, proj in self._projects.items():
             projMeta = self._projectMetadatas[key]
@@ -331,7 +330,7 @@ class PersistentConfiguration(ServerConfiguration):
         fname = projMeta['location']
         dirname = os.path.dirname(fname)
         return super().getProjectAsset(projectUid, os.path.join(dirname, location))
-    
+
     def addProjectAsset(self, projectUid, file):
         projMeta = self._projectMetadatas[projectUid]
         fname = projMeta['location']
@@ -339,7 +338,7 @@ class PersistentConfiguration(ServerConfiguration):
         fullpath = os.path.join(dirname, file.filename)
         file.save(fullpath)
         return file.filename
-            
+
     def _getStoreConfig(self):
         return json.dumps(self._config, indent=4, sort_keys=True)
 
@@ -444,7 +443,7 @@ class PersistentConfiguration(ServerConfiguration):
             content = fc.read()
             proj = jsonpickle.decode(content)
             proj._contentRoot = os.path.dirname(filepath)
-            proj.setDevice(self.createOutputDevice())
+            proj.setDevice(self._createOrReuseOutputDevice())
             return proj
 
     def _writeProject(self, proj, projFile):

--- a/server.py
+++ b/server.py
@@ -534,9 +534,6 @@ def strandTest(device, num_pixels):
 
 
 if __name__ == '__main__':
-    deviceRasp = 'RaspberryPi'
-    deviceCandy = 'FadeCandy'
-
     parser = argparse.ArgumentParser(description='MOLECOLE - A Modular LED Controller Workstation')
     parser.add_argument(
         '-C',
@@ -556,7 +553,7 @@ if __name__ == '__main__':
         '--device',
         dest='device',
         default=None,
-        choices=[deviceRasp, deviceCandy],
+        choices=[serverconfiguration.ServerConfiguration.getConfigurationParameters().get('device')],
         help='device to send RGB to (default: FadeCandy)')
     parser.add_argument(
         '--device_candy_server', dest='device_candy_server', default=None, help='Server for device FadeCandy')

--- a/server.py
+++ b/server.py
@@ -346,9 +346,7 @@ def create_app():
         if file and '.' in file.filename and file.filename.rsplit('.', 1)[1].lower() in ['gif']:
             print("Adding asset to proj {}".format(proj.id))
             filename = serverconfig.addProjectAsset(proj.id, file)
-            return jsonify({
-                'filename': filename
-            })
+            return jsonify({'filename': filename})
         print("Unknown content for asset: {}".format(file.filename))
         abort(400)
 
@@ -548,12 +546,13 @@ if __name__ == '__main__':
     parser.add_argument(
         '-N', '--num_pixels', dest='num_pixels', type=int, default=None, help='number of pixels (default: 300)')
     parser.add_argument('-R', '--num_rows', dest='num_rows', type=int, default=None, help='number of rows (default: 1)')
+    deviceChoices = serverconfiguration.ServerConfiguration.getConfigurationParameters().get('device')
     parser.add_argument(
         '-D',
         '--device',
         dest='device',
         default=None,
-        choices=[serverconfiguration.ServerConfiguration.getConfigurationParameters().get('device')],
+        choices=deviceChoices,
         help='device to send RGB to (default: FadeCandy)')
     parser.add_argument(
         '--device_candy_server', dest='device_candy_server', default=None, help='Server for device FadeCandy')
@@ -638,10 +637,8 @@ if __name__ == '__main__':
 
     # strand test
     if args.strand:
-        strandTest(
-            serverconfig.createOutputDevice()
-            , serverconfig.getConfiguration(serverconfiguration.CONFIG_NUM_PIXELS)
-        )
+        strandTest(serverconfig.createOutputDevice(),
+                   serverconfig.getConfiguration(serverconfiguration.CONFIG_NUM_PIXELS))
 
     # Initialize project
     proj = serverconfig.getActiveProjectOrDefault()

--- a/server.py
+++ b/server.py
@@ -641,21 +641,10 @@ if __name__ == '__main__':
 
     # strand test
     if args.strand:
-        device = None
-        if serverconfig.getConfiguration(serverconfiguration.CONFIG_DEVICE) == deviceRasp:
-            device = devices.RaspberryPi(
-                serverconfig.getConfiguration(serverconfiguration.CONFIG_NUM_PIXELS),
-                serverconfig.getConfiguration(serverconfiguration.CONFIG_NUM_ROWS),
-            )
-        elif serverconfig.getConfiguration(serverconfiguration.CONFIG_DEVICE) == deviceCandy:
-            device = devices.FadeCandy(
-                serverconfig.getConfiguration(serverconfiguration.CONFIG_NUM_PIXELS),
-                serverconfig.getConfiguration(serverconfiguration.CONFIG_NUM_ROWS),
-                serverconfig.getConfiguration(serverconfiguration.CONFIG_DEVICE_CANDY_SERVER))
-        else:
-            print("Unknown device: {}".format(serverconfig.getConfiguration(serverconfiguration.CONFIG_DEVICE)))
-            exit
-        strandTest(device, serverconfig.getConfiguration(serverconfiguration.CONFIG_NUM_PIXELS))
+        strandTest(
+            serverconfig.createOutputDevice()
+            , serverconfig.getConfiguration(serverconfiguration.CONFIG_NUM_PIXELS)
+        )
 
     # Initialize project
     proj = serverconfig.getActiveProjectOrDefault()


### PR DESCRIPTION
The contents of createOutputDevice() is duplicated between server.py and serverconfiguration.py. This code should be merged in the interest of DRY (and it was a pain to track everything down to set up a new device)

_createOutputDevice() was renamed createOutputDevice() as it's not private, and is now being used in server.py