### PR TITLE
Add buffer type to audio

### DIFF
--- a/audioled/audio.py
+++ b/audioled/audio.py
@@ -7,6 +7,7 @@ import numpy as np
 import pyaudio
 
 from audioled.effects import Effect
+from audioled.effect import AudioBuffer
 
 
 def print_audio_devices():
@@ -142,6 +143,7 @@ class AudioInput(Effect):
     def __initstate__(self):
         super(AudioInput, self).__initstate__()
         self._buffer = []
+        self._outBuffer = []
         self._autogain_perc = None
         self._cur_gain = 1.0
         print("Virtual audio input created. {} {}".format(GlobalAudio.device_index, GlobalAudio.chunk_rate))
@@ -203,6 +205,10 @@ class AudioInput(Effect):
             # perc = root(1.0 / min_value, N) = (1./min_value)**(1/N)
             self._autogain_perc = (1.0 / min_value)**float(1 / N)
         self._buffer = GlobalAudio.buffer
+        if len(self._outBuffer) != self.num_channels:
+            self._outBuffer = []
+            for i in range(0, self.num_channels):
+                self._outBuffer.append(AudioBuffer(GlobalAudio.sample_rate))
 
     def process(self):
         if self._inputBuffer is None or self._outputBuffer is None:
@@ -223,5 +229,6 @@ class AudioInput(Effect):
         for i in range(0, self.num_channels):
             # layout for multiple channel is interleaved:
             # 00 01 .. 0n 10 11 .. 1n
-            self._outputBuffer[i] = self._cur_gain * self._buffer[i::self.num_channels]
+            self._outBuffer[i].audio = self._cur_gain * self._buffer[i::self.num_channels]
+            self._outputBuffer[i] = self._outBuffer[i]
             # print("{}: {}".format(i, self._outputBuffer[i]))

--- a/audioled/audio.py
+++ b/audioled/audio.py
@@ -97,6 +97,9 @@ class GlobalAudio():
         return stream, int(device_info['defaultSampleRate'])
 
     def stream_audio(self, device_index=None, chunk_rate=60, channels=1):
+        if device_index == -1:
+            print("Audio device disabled by device_index -1.")
+            return None, None
         if device_index is None:
             print("No device_index for audio given. Using default.")
             p = pyaudio.PyAudio()

--- a/audioled/colors.py
+++ b/audioled/colors.py
@@ -125,7 +125,8 @@ class StaticRGBColor(Effect):
             self._color = np.ones(self._num_pixels) * np.array([[self.r], [self.g], [self.b]])
 
     def process(self):
-        self._outputBuffer[0] = self._color
+        if self._outputBuffer is not None:
+            self._outputBuffer[0] = self._color
 
 
 class ColorWheel(Effect):
@@ -237,8 +238,7 @@ class InterpolateRGB(Effect):
         return \
             "RGB interpolation between two color inputs."
 
-    def __init__(self, num_pixels):
-        self.num_pixels = num_pixels
+    def __init__(self):
         self.__initstate__()
 
     def numInputChannels(self):

--- a/audioled/configs.py
+++ b/audioled/configs.py
@@ -21,7 +21,7 @@ def createMovingLightGraph():
     color_wheel = colors.ColorWheel()
     fg.addEffectNode(color_wheel)
 
-    movingLight = audioreactive.MovingLight(fs=audio_in.getSampleRate())
+    movingLight = audioreactive.MovingLight()
     fg.addEffectNode(movingLight)
 
     mirrorLower = effects.Mirror(mirror_lower=True, recursion=0)
@@ -56,8 +56,7 @@ def createMovingLightsGraph():
     color_wheel1 = colors.ColorWheel()
     fg.addEffectNode(color_wheel1)
 
-    movingLight1 = audioreactive.MovingLight(
-        fs=audio_in.getSampleRate(), speed=150.0, dim_time=.5, highcut_hz=200)
+    movingLight1 = audioreactive.MovingLight(speed=150.0, dim_time=.5, highcut_hz=200)
     fg.addEffectNode(movingLight1)
 
     afterglow1 = effects.AfterGlow()
@@ -76,7 +75,7 @@ def createMovingLightsGraph():
     color_wheel2 = colors.ColorWheel()
     fg.addEffectNode(color_wheel2)
 
-    movingLight2 = audioreactive.MovingLight(audio_in.getSampleRate(), speed=150.0, dim_time=1.0, highcut_hz=500)
+    movingLight2 = audioreactive.MovingLight(speed=150.0, dim_time=1.0, highcut_hz=500)
     fg.addEffectNode(movingLight2)
 
     afterglow2 = effects.AfterGlow()
@@ -118,7 +117,7 @@ def createSpectrumGraph():
     color_wheel2 = colors.ColorWheel(cycle_time=15.0)
     fg.addEffectNode(color_wheel2)
 
-    spectrum = audioreactive.Spectrum(fs=audio_in.getSampleRate())
+    spectrum = audioreactive.Spectrum()
     fg.addEffectNode(spectrum)
 
     append = effects.Append(2, flip0=True)
@@ -366,7 +365,7 @@ def createBonfireGraph():
     led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
-    bonfire = audioreactive.Bonfire(fs=audio_in.getSampleRate())
+    bonfire = audioreactive.Bonfire()
     fg.addEffectNode(bonfire)
 
     testblob = generative.StaticBlob()

--- a/audioled/dsp.py
+++ b/audioled/dsp.py
@@ -5,7 +5,7 @@ import itertools
 import math
 
 import numpy as np
-from scipy.signal import butter, lfilter_zi
+from scipy.signal import butter, lfilter_zi, lfilter
 
 
 def rollwin(signal, n_overlaps):
@@ -220,3 +220,24 @@ def design_filter(lowcut, highcut, fs, order=3):
     high = highcut / nyq
     b, a = butter(order, [low, high], btype='band')
     return b, a, lfilter_zi(b, a)
+
+
+class Bandpass():
+    def __init__(self, lowcut, highcut, fs, order=3):
+        self._fs = fs
+        self._filter_a = None
+        self._filter_b = None
+        self._filter_zi = None
+        self._lowcut = lowcut
+        self._highcut = highcut
+        self._order = order
+        self._initFilter()
+         
+    def filter(self, audio, fs):
+        if fs != self._fs:
+            self._initFilter()
+        y, self._filter_zi = lfilter(b=self._filter_b, a=self._filter_a, x=audio, zi=self._filter_zi)
+        return y
+
+    def _initFilter(self):
+        self._filter_b, self._filter_a, self._filter_zi = design_filter(self._lowcut, self._highcut, self._fs, self._order)

--- a/audioled/effect.py
+++ b/audioled/effect.py
@@ -1,6 +1,18 @@
 import inspect
 
 
+class PixelBuffer(object):
+    def __init__(self):
+        super().__init__()
+
+
+class AudioBuffer(object):
+    def __init__(self, sample_rate):
+        super().__init__()
+        self.audio = None
+        self.sample_rate = sample_rate
+
+
 class Effect(object):
     """
     Base class for effects
@@ -127,13 +139,17 @@ class Effect(object):
     def getEffectDescription():
         return ""
 
-    def _inputBufferValid(self, index):
+    def _inputBufferValid(self, index, buffer_type=PixelBuffer.__name__):
         if self._inputBuffer is None:
             return False
         if len(self._inputBuffer) <= index:
             return False
         if self._inputBuffer[index] is None:
             return False
+        if buffer_type is AudioBuffer.__name__:
+            if not isinstance(self._inputBuffer[index], AudioBuffer):
+                raise RuntimeError("Input {}: Audio input expected.".format(index))
+
         return True
 
     def setNumOutputPixels(self, num_pixels):

--- a/audioled/effects.py
+++ b/audioled/effects.py
@@ -13,7 +13,6 @@ SHORT_NORMALIZE = 1.0 / 32768.0
 
 
 class Shift(Effect):
-
     @staticmethod
     def getEffectDescription():
         return \
@@ -79,7 +78,6 @@ class Shift(Effect):
 
 
 class Append(Effect):
-
     @staticmethod
     def getEffectDescription():
         return \
@@ -169,7 +167,6 @@ class Append(Effect):
 
     def process(self):
         if self._inputBuffer is None or self._outputBuffer is None:
-            self._outputBuffer[0] = None
             return
         if self._inputBuffer[0] is None:
             self._outputBuffer[0] = None
@@ -192,7 +189,6 @@ class Append(Effect):
 
 
 class Combine(Effect):
-
     @staticmethod
     def getEffectDescription():
         return \
@@ -247,7 +243,6 @@ class Combine(Effect):
 
 
 class AfterGlow(Effect):
-
     @staticmethod
     def getEffectDescription():
         return \
@@ -307,7 +302,6 @@ class AfterGlow(Effect):
 
     def process(self):
         if self._inputBuffer is None or self._outputBuffer is None:
-            self._outputBuffer[0] = None
             return
         y = self._inputBuffer[0]
         if y is None:
@@ -327,7 +321,6 @@ class AfterGlow(Effect):
 
 
 class Mirror(Effect):
-
     @staticmethod
     def getEffectDescription():
         return \
@@ -556,6 +549,8 @@ class SpringCombine(Effect):
 
     async def update(self, dt):
         await super().update(dt)
+        if self._num_pixels is None:
+            return
         if self._pos is None or len(self._pos) != self._num_pixels:
             self._pos = np.zeros(self._num_pixels)
         if self._vel is None or len(self._vel) != self._num_pixels:

--- a/audioled/panelize.py
+++ b/audioled/panelize.py
@@ -75,6 +75,8 @@ class MakeSquare(Effect):
 
     async def update(self, dt):
         await super().update(dt)
+        if self._num_pixels is None:
+            return
         if self._mapMask is None or np.size(self._mapMask, 1) != self._num_pixels:
             self._mapMask = self._genMapMask(self._num_pixels, self._num_rows, self.displacement,
                                              self.input_displacement)
@@ -276,6 +278,8 @@ class MakeLabyrinth(Effect):
 
     async def update(self, dt):
         await super().update(dt)
+        if self._num_pixels is None:
+            return
         if self._mapMask is None or np.size(self._mapMask, 1) != self._num_pixels:
             self._mapMask = self._genMapMask(self._num_pixels, self._num_rows)
 

--- a/filtergraphDemo.py
+++ b/filtergraphDemo.py
@@ -127,6 +127,7 @@ else:
 
 
 def createFilterGraph(config, num_pixels):
+    print("Creating config {}".format(config))
     if config == movingLightConf:
         return configs.createMovingLightGraph()
     elif config == movingLightsConf:

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import absolute_import
 import unittest
+import asyncio
 from audioled import effects, audio, audioreactive, colors, generative  # noqa: F401
 
 
@@ -33,6 +34,19 @@ class Test_Effects(unittest.TestCase):
                     effectsWithMissingParameterDescription.append("{} has no parameter help at all".format(_class))
 
         self.assertEqual([], effectsWithMissingParameterDescription)
+    
+    def test_allEffectsUpdateAndProcessWithoutConnection(self):
+        childclasses = inheritors(effects.Effect)
+        for _class in childclasses:
+            instance = None
+            try:
+                instance = _class()
+            except Exception as e:
+                print("Error instanciating effect {}".format(_class.__name__))
+                raise ValueError("Error instanciating effect {}: {}".format(_class.__name__, e)) from e
+            event_loop = asyncio.get_event_loop()
+            event_loop.run_until_complete(instance.update(0.01))
+            instance.process()
 
 
 def inheritors(klass):

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 import unittest
 import asyncio
-from audioled import effects, audio, audioreactive, colors, generative  # noqa: F401
+from audioled import effects, audio, audioreactive, colors, generative, panelize  # noqa: F401
 
 
 class Test_Effects(unittest.TestCase):


### PR DESCRIPTION
Added a specific buffer for audio that also passes sample rate information to the effect.
Effects can now validate that the input signal is indeed audio.
When adding a connection from a non-audio output to an audio input, an error will be shown in the UI.

This resolves #20.
This resolves #12.