### PR TITLE
DotStar LED's

### DIFF
--- a/audioled/devices.py
+++ b/audioled/devices.py
@@ -314,13 +314,13 @@ class DotStar(LEDController):
             Global brightness
         """
         try:
-            import apa102
+            from driver import apa102
         except ImportError as e:
             url = 'https://github.com/tinue/APA102_Pi'
             print('Could not import the apa102 library')
             print('For installation instructions, see {}'.format(url))
             raise e
-        self._strip = apa102.APA102(numLEDs=num_pixels, globalBrightness=brightness)  # Initialize the strip
+        self._strip = apa102.APA102(num_led=num_pixels)  # Initialize the strip
         led_data = np.array(self._strip.leds, dtype=np.uint8)
         # memoryview preserving the first 8 bits of LED frames (w/ global brightness)
         self._strip.leds = led_data.data

--- a/audioled/serverconfiguration.py
+++ b/audioled/serverconfiguration.py
@@ -34,7 +34,7 @@ class ServerConfiguration:
         return {
             CONFIG_NUM_PIXELS: [300, 1, 2000, 1],
             CONFIG_NUM_ROWS: [1, 1, 100, 1],
-            CONFIG_DEVICE: ['FadeCandy', 'RaspberryPi'],
+            CONFIG_DEVICE: ['FadeCandy', 'RaspberryPi', 'DotStar'],
         }
 
     def setConfiguration(self, key, value):
@@ -171,6 +171,10 @@ class ServerConfiguration:
                 self.getConfiguration(CONFIG_NUM_PIXELS), self.getConfiguration(CONFIG_NUM_ROWS))
         elif self.getConfiguration(CONFIG_DEVICE) == devices.FadeCandy.__name__:
             device = devices.FadeCandy(
+                self.getConfiguration(CONFIG_NUM_PIXELS), self.getConfiguration(CONFIG_NUM_ROWS),
+                self.getConfiguration(CONFIG_DEVICE_CANDY_SERVER))
+        elif self.getConfiguration(CONFIG_DEVICE) == devices.DotStar.__name__:
+            device = devices.DotStar(
                 self.getConfiguration(CONFIG_NUM_PIXELS), self.getConfiguration(CONFIG_NUM_ROWS),
                 self.getConfiguration(CONFIG_DEVICE_CANDY_SERVER))
         else:


### PR DESCRIPTION
This PR resolves #121.

Server and Demo can now be started with `-D DotStar` for DotStar LED device.